### PR TITLE
Align projects to new CI requirements

### DIFF
--- a/boing-ggez/src/main.rs
+++ b/boing-ggez/src/main.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::type_complexity, clippy::comparison_chain)]
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
 
 mod audio_entity;
 mod ball;

--- a/cavern-macroquad/src/main.rs
+++ b/cavern-macroquad/src/main.rs
@@ -1,12 +1,5 @@
-#![allow(
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::comparison_chain,
-    clippy::derive_partial_eq_without_eq,
-    clippy::len_zero,
-    clippy::manual_range_contains,
-    clippy::type_complexity
-)]
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
 
 mod actor;
 mod bolt;

--- a/rusty_roguelike-bevy/src/main.rs
+++ b/rusty_roguelike-bevy/src/main.rs
@@ -95,8 +95,7 @@ impl State {
         self.ecs.insert_resource(map_builder.map);
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
-        self.ecs
-            .insert_resource(TurnState::AwaitingInput);
+        self.ecs.insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -160,8 +159,7 @@ impl State {
         self.ecs
             .world
             .insert_resource(Camera::new(map_builder.player_start));
-        self.ecs
-            .insert_resource(TurnState::AwaitingInput);
+        self.ecs.insert_resource(TurnState::AwaitingInput);
         self.ecs.world.insert_resource(map_builder.theme);
     }
 

--- a/rusty_roguelike-bevy/src/main.rs
+++ b/rusty_roguelike-bevy/src/main.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
+
 mod camera;
 mod components;
 mod events;

--- a/rusty_roguelike-macroquad/src/main.rs
+++ b/rusty_roguelike-macroquad/src/main.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
+
 mod camera_view;
 mod components;
 mod macroquad_utils;

--- a/soccer-fyrox/src/main.rs
+++ b/soccer-fyrox/src/main.rs
@@ -1,15 +1,5 @@
-#![deny(clippy::all)]
-#![allow(
-    clippy::assign_op_pattern,
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::comparison_chain,
-    clippy::len_zero,
-    clippy::manual_range_contains,
-    clippy::new_without_default,
-    clippy::too_many_arguments,
-    clippy::type_complexity
-)]
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
 
 mod anchor;
 mod ball;


### PR DESCRIPTION
- Apply cargo fmt to rusty_roguelike-bevy
- (Convenience) Set project-level clippy lints for all the projects